### PR TITLE
readme: fix list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ On GNOME3 and possibly other systems, if the vsync extension is not working (ie.
 
 Compilation instructions on Mac OS X:
 
-1) Install Xcode and command line tools (as of Xcode 4.3.x, from
+1. Install Xcode and command line tools (as of Xcode 4.3.x, from
    within Preferences -> Downloads).
-2) Install MacPorts.
-3) sudo port install automake autoconf libtool pkgconfig freetype
-4) ./autogen.sh
-5) make
+2. Install MacPorts.
+3. `sudo port install automake autoconf libtool pkgconfig freetype`
+4. `./autogen.sh`
+5. `make`


### PR DESCRIPTION
Fixed the list so that it renders correctly.

On a related note, would a pull request to switch to [Homebrew](https://brew.sh/) instead of MacPorts be accepted? These days, Homebrew are much more widely used and recommended to use instead.