### PR TITLE
Improve win32 build files

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,21 +3,9 @@ install:
   - git clone https://github.com/Microsoft/vcpkg
   - cd vcpkg
   - powershell -exec bypass scripts\bootstrap.ps1
-  - vcpkg install glew freetype
+  - vcpkg install glew freetype freeglut
   - vcpkg integrate install
-  - copy installed\x86-windows\include\freetype2\ft2build.h "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include"
-  - xcopy installed\x86-windows\include\freetype2 "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\freetype\" /S
-  - xcopy installed\x86-windows\lib "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\lib\"
   - cd ..
 
-  # Someone should put a freeglut on vcpkg but till then, download and install glut manually
-  - appveyor DownloadFile https://www.opengl.org/resources/libraries/glut/glutdlls37beta.zip
-  - 7z x glutdlls37beta.zip
-  - copy glut32.dll "C:\Windows\SysWOW64\"
-  - md "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\GL"
-  - copy glut.h "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\GL"
-  - copy glut32.lib "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\lib"
-
 build_script:
-  - cd win32
-  - msbuild glyphy.sln
+  - msbuild win32\glyphy.sln

--- a/win32/glyphy-demo.vcxproj
+++ b/win32/glyphy-demo.vcxproj
@@ -58,10 +58,10 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>glew32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>cscript $(MSBuildStartupDirectory)\stringize.js "$(MSBuildStartupDirectory)\..\demo"</Command>
+      <Command>cscript "$(MSBuildProjectDirectory)\stringize.js" "$(MSBuildProjectDirectory)\..\demo"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -81,7 +81,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PreBuildEvent>
-      <Command>cscript $(MSBuildStartupDirectory)\stringize.js "$(MSBuildStartupDirectory)\..\demo"</Command>
+      <Command>cscript "$(MSBuildProjectDirectory)\stringize.js" "$(MSBuildProjectDirectory)\..\demo"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/win32/glyphy.vcxproj
+++ b/win32/glyphy.vcxproj
@@ -63,7 +63,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <Command>cscript $(MSBuildStartupDirectory)\stringize.js "$(MSBuildStartupDirectory)\..\src"</Command>
+      <Command>cscript "$(MSBuildProjectDirectory)\stringize.js" "$(MSBuildProjectDirectory)\..\src"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -83,7 +83,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PreBuildEvent>
-      <Command>cscript $(MSBuildStartupDirectory)\stringize.js "$(MSBuildStartupDirectory)\..\src"</Command>
+      <Command>cscript "$(MSBuildProjectDirectory)\stringize.js" "$(MSBuildProjectDirectory)\..\src"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
- Use better variables on prebuild event
- freeglut is added on vcpkg so no longer manual download is needed

Depends on https://github.com/Microsoft/vcpkg/pull/138
