### PR TITLE
Fix #ifdef does not have an expression

### DIFF
--- a/demo/glyphy-demo.cc
+++ b/demo/glyphy-demo.cc
@@ -256,7 +256,7 @@ main (int argc, char** argv)
   {
 #ifdef _WIN32
     FT_New_Face(ft_library, "C:\\Windows\\Fonts\\calibri.ttf", 0/*face_index*/, &ft_face);
-#elif
+#else
     #include "default-font.h"
     FT_New_Memory_Face (ft_library, (const FT_Byte *) default_font, sizeof (default_font), 0/*face_index*/, &ft_face);
 #endif


### PR DESCRIPTION
I got the following error, and I fix it to run the demo.
```
  CXX      glyphy_demo-glyphy-demo.o
glyphy-demo.cc:259:6: error: #elif with no expression
 #elif
      ^
make[4]: *** [Makefile:698: glyphy_demo-glyphy-demo.o] Error 1
```