### PR TITLE
Meson improvements

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -48,4 +48,10 @@ libglyphy = library('glyphy', glyphy_sources + glyphy_headers + glyphy_shader_so
   version: '0.0.0',
   install: true)
 
+libglyphy_dep = declare_dependency(
+  link_with: libglyphy,
+  include_directories: [confinc])
+
+meson.override_dependency('glyphy', libglyphy_dep)
+
 install_headers(glyphy_headers, subdir: meson.project_name())

--- a/src/meson.build
+++ b/src/meson.build
@@ -54,4 +54,8 @@ libglyphy_dep = declare_dependency(
 
 meson.override_dependency('glyphy', libglyphy_dep)
 
+libglyphy_pc = pkgmod.generate(libglyphy,
+  description: 'High-quality glyph rendering library using OpenGL ES2 shaders',
+  subdirs: meson.project_name())
+
 install_headers(glyphy_headers, subdir: meson.project_name())


### PR DESCRIPTION
 * Add a libglyphy_dep which can be automatically accessed via subprojects
 * Install a pkgconfig

I do think that, from the GTK standpoint, we'd probably still want to statically link glyphy, but I'll look into that later.