### PR TITLE
harfbuzz: fix get_draw_funcs prototype

### DIFF
--- a/src/glyphy-harfbuzz.h
+++ b/src/glyphy-harfbuzz.h
@@ -89,7 +89,7 @@ glyphy_harfbuzz(cubic_to) (hb_draw_funcs_t *dfuncs,
 }
 
 static hb_draw_funcs_t *
-glyphy_harfbuzz(get_draw_funcs) ()
+glyphy_harfbuzz(get_draw_funcs) (void)
 {
   static hb_draw_funcs_t *dfuncs = NULL;
 


### PR DESCRIPTION
From C, (void) is needed to avoid compiler warnings such as:

 92 | glyphy_harfbuzz(get_draw_funcs) ()
 glyphy-harfbuzz.h: In function ‘glyphy_harfbuzz_get_draw_funcs’:
 glyphy-harfbuzz.h:31:32: warning: old-style function definition [-Wold-style-definition]