### PR TITLE
glyphy-demo.cc: Fix build on Visual Studio

### DIFF
--- a/demo/glyphy-demo.cc
+++ b/demo/glyphy-demo.cc
@@ -52,7 +52,7 @@ static int isroot(const char *path)
 static char *basename(char *path)
 {
   if (path == NULL || *path == '\0')
-    return ".";
+    return (char *)".";
 
   while ((path[strlen(path)-1] == '/' ||
 	  path[strlen(path)-1] == '\\') &&
@@ -190,7 +190,7 @@ main (int argc, char** argv)
   const char *text = NULL;
   const char *font_path = NULL;
   char arg;
-  while ((arg = getopt(argc, argv, "t:f:h")) != -1) {
+  while ((arg = getopt(argc, argv, (char *)"t:f:h")) != -1) {
     switch (arg) {
     case 't':
       text = optarg;


### PR DESCRIPTION
Hi,

This attempts to fix compiling `glyphy-demo.cc` on Visual Studio since in C++11 one is not allowed to assign a constant string literal (char array) to a non-const `char*` without an explicit cast[1].  It's some fact of life, sadly--I've yet to find a compiler flag that does what the accepted answer in the given SO link says that some compilers support, so please let me know if there is one for Visual Studio.

[1]: https://stackoverflow.com/questions/54100488/c2440-cannot-convert-from-const-char-9-to-char

With blessings, thank you!