### PR TITLE
Fix Meson builds for Visual Studio

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,12 @@ else
   ]), language: 'cpp')
 endif
 
+if is_msvc_like
+  add_project_arguments(cpp.get_supported_arguments([
+    '-D_USE_MATH_DEFINES', # For using _M_SQRT* etc with MSVC headers
+  ]), language: ['c', 'cpp'])
+endif
+
 glyphy_conf = configuration_data()
 
 freetype_dep = dependency(is_msvc_like ? 'freetype': 'freetype2', required: true)

--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,7 @@ endif
 if is_msvc_like
   add_project_arguments(cpp.get_supported_arguments([
     '-D_USE_MATH_DEFINES', # For using _M_SQRT* etc with MSVC headers
+    '-DNOMINMAX',          # We don't want min/max in windows.h to get in the way
   ]), language: ['c', 'cpp'])
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -46,7 +46,7 @@ endif
 
 glyphy_conf = configuration_data()
 
-freetype_dep = dependency('freetype2', required: true)
+freetype_dep = dependency(is_msvc_like ? 'freetype': 'freetype2', required: true)
 harfbuzz_dep = dependency('harfbuzz', version: '>= 4.0.0', required: true)
 gl_dep = dependency('gl', required: true)
 glew_dep = dependency('glew', required: false)

--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,10 @@ project('glyphy', 'c', 'cpp',
 pkgmod = import('pkgconfig')
 cpp = meson.get_compiler('cpp')
 
-if cpp.get_id() == 'msvc'
+is_msvc = cpp.get_id() == 'msvc'
+is_msvc_like = is_msvc or cpp.get_argument_syntax() == 'msvc'
+
+if is_msvc
   # Ignore several spurious warnings for things HarfBuzz does very commonly.
   # If a warning is completely useless and spammy, use '/wdXXXX' to suppress it
   # If a warning is harmless but hard to fix, use '/woXXXX' so it's shown once

--- a/meson.build
+++ b/meson.build
@@ -31,18 +31,18 @@ if is_msvc
   # noseh_link_args = ['/SAFESEH:NO']
   # disable exception handling
   add_project_arguments(['/EHs-', '/EHc-'], language: 'cpp')
+else
+  add_project_link_arguments(cpp.get_supported_link_arguments([
+    '-Bsymbolic-functions'
+  ]), language: 'c')
+
+  add_project_arguments(cpp.get_supported_arguments([
+    '-fno-exceptions',
+    '-fno-rtti',
+    '-fno-threadsafe-statics',
+    '-fvisibility-inlines-hidden',
+  ]), language: 'cpp')
 endif
-
-add_project_link_arguments(cpp.get_supported_link_arguments([
-  '-Bsymbolic-functions'
-]), language: 'c')
-
-add_project_arguments(cpp.get_supported_arguments([
-  '-fno-exceptions',
-  '-fno-rtti',
-  '-fno-threadsafe-statics',
-  '-fvisibility-inlines-hidden',
-]), language: 'cpp')
 
 glyphy_conf = configuration_data()
 


### PR DESCRIPTION
Hi,

This PR attempts to update the Meson build files to build Glyphy with Visual Studio (and possibly others compilers that attempt to be MSVC-like such as clang-cl), by doing the following:

Please note that this depends on PR #46 for a complete build and currently supports static builds only.  DLL builds are for another PR.  I will try to look at converting the `stringize` script into Python, but I think that is for yet another PR.  So a shell script interpreter from Cygwin or MSYS2 is required at the moment.

*  Use CMake to find FreeType, which uses a different naming (and versioning scheme, if we use that in the future).  Basically, it does the manual header and .lib search for us in a rather decent and comprehensive way.  Not sure about GLUT or GLEW though, although I was able to have Meson find them on my system without further intervention.  HarfBuzz, on the other hand, has the pkg-config files we need from its Meson build.
* Define `NOMINMAX` since we don't want `min` and `max` defined in `windows.h` to get in our way.
* Define `_USE_MATH_DEFINES` since we need access to the `_M_SQRT*` (and so forth) macros in `math.h` as supplied from Visual Studio.
* Save some time for MSVC builds by not checking for CXXFlags or linker flags that are clearly for GCC-esque compilers.

With blessings, thank you!