### PR TITLE
meson.build: Fix usage as subprojects

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -53,7 +53,12 @@ endif
 
 glyphy_conf = configuration_data()
 
-freetype_dep = dependency(is_msvc_like ? 'freetype': 'freetype2', required: true)
+freetype_dep = dependency('freetype2', method: 'pkg-config', required: not is_msvc_like)
+
+# Merge into above line when we require Meson 0.60.0 or later
+if not freetype_dep.found()
+  freetype_dep = dependency('Freetype', method: 'cmake', required: true)
+endif
 harfbuzz_dep = dependency('harfbuzz', version: '>= 4.0.0', required: true)
 gl_dep = dependency('gl', required: true)
 glew_dep = dependency('glew', required: false)


### PR DESCRIPTION
Hi,

From Eli's suggestions at [1], we split up looking for FreeType (yes, I understand the casing--the "FreeType" here is for the branding, I used `Freetype` in the CMake dep name) in 2 steps for Visual Studio-like builds, first the pkg-config way, and then the CMake way.

Builds for non-Visual Studio-like compilers should not be affected by this change.

With blessings, thank you!

[1]:https://github.com/behdad/glyphy/pull/47#issuecomment-1079065898