### PR TITLE
meson:build Fix usage as subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -88,7 +88,7 @@ endif
 glyphy_conf.set_quoted('PKGDATADIR', pkgdatadir)
 
 configure_file(output: 'config.h', configuration: glyphy_conf)
-confinc = include_directories('.')
+confinc = include_directories('.', 'src')
 
 subdir('src')
 


### PR DESCRIPTION
We need to add src/ as an include dir in the
declare_dependency call so the parent projects
build will find the uninstalled glyphy.h there.