### PR TITLE
Don't feed -D through cpp.get_supported_arguments

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,10 +45,10 @@ else
 endif
 
 if is_msvc_like
-  add_project_arguments(cpp.get_supported_arguments([
+  add_project_arguments([
     '-D_USE_MATH_DEFINES', # For using _M_SQRT* etc with MSVC headers
     '-DNOMINMAX',          # We don't want min/max in windows.h to get in the way
-  ]), language: ['c', 'cpp'])
+  ], language: ['c', 'cpp'])
 endif
 
 glyphy_conf = configuration_data()


### PR DESCRIPTION
It doesn't seem necessary and, in fact, it seems to make it so those arguments never make it to the build, breaking it.

This is untested. We can either merge it as-is, or I can temporarily point my gtk subproject at this branch and see if it helps.