### PR TITLE
Fix build and stringize to correctly generate header files

### DIFF
--- a/demo/Makefile.am
+++ b/demo/Makefile.am
@@ -76,7 +76,7 @@ EXTRA_DIST += $(SHADERS)
 
 %-glsl.h: %.glsl $(top_srcdir)/src/stringize
 	$(AM_V_GEN) $(top_srcdir)/src/stringize "static const char *`echo "$<" | \
-	sed 's@.*/@@;s/[-.]/_/g'`" < "$<" > "$@.tmp" && \
+	sed 's@.*/@@;s/[-.]/_/g'`" "$<" > "$@.tmp" && \
 	mv "$@.tmp" "$@" || ($(RM) "$@.tmp"; false)
 
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,7 +52,7 @@ pkgdata_DATA = \
 EXTRA_DIST += stringize
 %-glsl.h: %.glsl stringize
 	$(AM_V_GEN) $(srcdir)/stringize "static const char *`echo "$<" | \
-	sed 's@.*/@@;s/[-.]/_/g'`" < "$<" > "$@.tmp" && \
+	sed 's@.*/@@;s/[-.]/_/g'`" "$<" > "$@.tmp" && \
 	mv "$@.tmp" "$@" || ($(RM) "$@.tmp"; false)
 
 

--- a/src/stringize
+++ b/src/stringize
@@ -18,11 +18,11 @@ except IndexError:
 
 file = open(filename, 'r')
 
-print(f'{decl} = ')
+print(f'{decl} =')
 text = file.read(-1)
 lines = text.splitlines()
 for line in lines:
-    line.replace(r'\\', r'\\\\')
-    line.replace(r'"', r'\\"')
-    print(f'"{line}"')
+    line = line.replace(r'\\', r'\\\\')
+    line = line.replace(r'"', r'\"')
+    print(f'"{line}\\n"')
 print(';')

--- a/src/stringize
+++ b/src/stringize
@@ -1,9 +1,20 @@
 #! /usr/bin/env python3
 
-import os, sys, re
+import os
+import sys
+import re
 
-decl = sys.argv[1]
-filename = sys.argv[2]
+try:
+    decl = sys.argv[1]
+except IndexError:
+    sys.stderr.write("stringize: missing declaration: {}\n".format(sys.argv))
+    sys.exit(1)
+
+try:
+    filename = sys.argv[2]
+except IndexError:
+    sys.stderr.write("stringize: missing filename: {}\n".format(sys.argv))
+    sys.exit(1)
 
 file = open(filename, 'r')
 


### PR DESCRIPTION
The build is broken as of:  e3f5e03727
```
$ make
make  all-recursive
make[1]: Entering directory '/home/user/Projects/glyphy'
Making all in src
make[2]: Entering directory '/home/user/Projects/glyphy/src'
  GEN      glyphy-common-glsl.h
Traceback (most recent call last):
  File "/home/user/Projects/glyphy/src/./stringize", line 6, in <module>
    filename = sys.argv[2]
IndexError: list index out of range
make[2]: *** [Makefile:874: glyphy-common-glsl.h] Error 1
make[2]: Leaving directory '/home/user/Projects/glyphy/src'
make[1]: *** [Makefile:491: all-recursive] Error 1
make[1]: Leaving directory '/home/user/Projects/glyphy'
make: *** [Makefile:400: all] Error 2
```

These commits  fix the build