### PR TITLE
Add Github Actions CI Workflow to build/test on Ubuntu 22.04

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,42 @@
+name: Linux CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache Harfbuzz
+        uses: actions/cache@v3
+        with:
+          path: harfbuzz-7.3.0
+          key: ${{ runner.os }}-build
+      - name: Install build dependencies
+        run: sudo apt install -y curl gcc g++ libfreetype6-dev libglib2.0-dev libcairo2-dev make cmake automake autoconf libtool libharfbuzz-dev meson freeglut3-dev libglew-dev
+      - name: Download a recent harfbuzz archive
+        # TODO: Ubuntu 22.04 has harfbuzz < 4.0.0. Ubuntu 24.04 will have harfbuzz >= 4.0.0.
+        # The harfbuzz build will not be required when Github updates the runners.
+        run: curl -L https://github.com/harfbuzz/harfbuzz/releases/download/7.3.0/harfbuzz-7.3.0.tar.xz -O
+      - name: Decompress harfbuzz archive
+        run: tar xvf harfbuzz-7.3.0.tar.xz
+      - name: Configure harfbuzz build
+        run: cd harfbuzz-7.3.0; meson setup build
+      - name: Build harfbuzz
+        run: cd harfbuzz-7.3.0; meson compile -C build
+      - name: Install harfbuzz
+        run: cd harfbuzz-7.3.0; sudo meson install -C build
+      - name: Configure glyphy
+        run: ./autogen.sh
+      - name: Make glyphy
+        run: make
+      - name: Meson setup
+        run: meson setup build
+      - name: Meson compile
+        run: meson compile -C build
+      - name: Run Validator against default font
+        run: ./demo/glyphy-validate ./demo/default-font.ttf

--- a/meson.build
+++ b/meson.build
@@ -62,7 +62,7 @@ endif
 harfbuzz_dep = dependency('harfbuzz', version: '>= 4.0.0', required: true)
 gl_dep = dependency('gl', required: true)
 glew_dep = dependency('glew', required: false)
-glut_dep = dependency('glut', required: get_option('demo').enabled())
+glut_dep = dependency('GLUT', required: get_option('demo').enabled())
 
 prefix = get_option('prefix')
 libdir = join_paths(prefix, get_option('libdir'))
@@ -110,4 +110,3 @@ summary('prefix', prefix, section: 'Directories')
 summary('includedir', includedir, section: 'Directories')
 summary('libdir', libdir, section: 'Directories')
 summary('datadir', datadir, section: 'Directories')
-


### PR DESCRIPTION
Builds the library, demo, and runs the validator. This will help avoid a broken build in the future.

meson.build has been updated to capitalize the GLUT dependency name so it is detected correctly by Meson. Is this an  issue on other architectures?

Note: Github CI runners are Ubuntu 22.04, which has an old version of harfbuzz, so harfbuzz must be built from source. The harfbuzz build can be removed when Github updates the CI runners to Ubuntu 24.04.

An example workflow build log is available here: https://github.com/13rac1/glyphy/actions/runs/5457958933/jobs/9932527922